### PR TITLE
Return 400 instead of crashing on bad PUT body

### DIFF
--- a/httpserver/http_server.go
+++ b/httpserver/http_server.go
@@ -52,7 +52,8 @@ func putHandler(w http.ResponseWriter, r *http.Request, gerdu cache.UnImplemente
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(r.Body)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Errorf("HTTP PUT: failed to read body: %v", err)
+		http.Error(w, "failed to read request body", http.StatusBadRequest)
 		return
 	}
 	value := buf.String()
@@ -131,7 +132,12 @@ func joinHandler(w http.ResponseWriter, r *http.Request, gerdu cache.UnImplement
 func leaveHandler(w http.ResponseWriter, r *http.Request, gerdu cache.UnImplementedCache) {
 	raftCache := gerdu.(*raftproxy.RaftProxy)
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(r.Body)
+	_, err := buf.ReadFrom(r.Body)
+	if err != nil {
+		log.Errorf("HTTP LEAVE: failed to read body: %v", err)
+		http.Error(w, "failed to read request body", http.StatusBadRequest)
+		return
+	}
 	nodeId := buf.String()
 
 	if nodeId == "" {

--- a/httpserver/http_server_test.go
+++ b/httpserver/http_server_test.go
@@ -3,11 +3,38 @@ package httpserver
 import (
 	"github.com/arazmj/gerdu/lrucache"
 	"github.com/gorilla/mux"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}
+
+func TestPutHandlerBadBody(t *testing.T) {
+	gerdu := lrucache.NewCache(1)
+	router := mux.NewRouter()
+	router.HandleFunc("/cache/{key}", func(w http.ResponseWriter, r *http.Request) {
+		putHandler(w, r, gerdu)
+	}).Methods(http.MethodPut)
+
+	req := httptest.NewRequest(http.MethodPut, "/cache/bad", errorReader{})
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Failed to produce expected status code %d, got %d", http.StatusBadRequest, w.Code)
+	}
+	if _, ok := gerdu.Get("bad"); ok {
+		t.Error("bad body should not be stored in cache")
+	}
+}
 
 func TestIndexHandler(t *testing.T) {
 	gerdu := lrucache.NewCache(2)


### PR DESCRIPTION
## Summary
- return HTTP 400 when PUT request body reads fail instead of exiting the server
- return HTTP 400 when leave request body reads fail
- add bad-body PUT handler coverage

## Validation
- go build ./...
- go test ./httpserver/...