### PR TITLE
Lock LRU Delete and decrement cache size

### DIFF
--- a/lrucache/lru_cache.go
+++ b/lrucache/lru_cache.go
@@ -79,9 +79,13 @@ func (c *LRUCache) Put(key string, value string) (created bool) {
 
 //applyDelete the key from the node
 func (c *LRUCache) Delete(key string) (ok bool) {
+	c.Lock()
+	defer c.Unlock()
+
 	if node, ok := c.node[key]; ok {
 		metrics.Deletes.Inc()
 		c.linklist.RemoveNode(node)
+		c.size -= bytesize.ByteSize(len(node.Value))
 		delete(c.node, key)
 	} else {
 		return false

--- a/lrucache/lru_cache_test.go
+++ b/lrucache/lru_cache_test.go
@@ -72,3 +72,52 @@ func TestLruCache_Delete(t *testing.T) {
 		t.Fatal("Expected the ket to be deleted")
 	}
 }
+
+func TestDeleteDecrementsSize(t *testing.T) {
+	cache := NewCache(4)
+	deletedValue := "aa"
+	remainingValue := "bb"
+	newValue := "cc"
+
+	cache.Put("deleted", deletedValue)
+	sizeAfterFirstPut := cache.size
+	cache.Put("remaining", remainingValue)
+	sizeAfterSecondPut := cache.size
+
+	if !cache.Delete("deleted") {
+		t.Fatal("expected delete to report success")
+	}
+
+	expectedSize := sizeAfterSecondPut - bytesize.ByteSize(len(deletedValue))
+	if cache.size != expectedSize {
+		t.Fatalf("expected size to drop from %s to %s after deleting %q, got %s", sizeAfterSecondPut, expectedSize, deletedValue, cache.size)
+	}
+	if expectedSize != sizeAfterFirstPut {
+		t.Fatalf("expected remaining size %s to match first put size %s", expectedSize, sizeAfterFirstPut)
+	}
+
+	cache.Put("new", newValue)
+	if value, ok := cache.Get("remaining"); !ok || value != remainingValue {
+		t.Fatalf("expected remaining entry to survive equivalent-size put, got %q %t", value, ok)
+	}
+}
+
+func TestDeleteConcurrentSafe(t *testing.T) {
+	capacity, _ := bytesize.Parse("1KB")
+	cache := NewCache(capacity)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				key := strconv.Itoa((i + 1) * j)
+				cache.Put(key, key)
+				cache.Delete(key)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- Lock LRUCache.Delete to avoid races with Get/Put
- Decrement cache size when Delete removes an entry
- Add size regression and concurrent Delete tests

## Validation
- go build ./...
- go test ./lrucache/...
- go test -race ./lrucache/... (blocked locally: cgo requires gcc, not installed in PATH)