### PR TITLE
Modernize CI: Go 1.21, v5 actions, lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,43 +7,38 @@ on:
     branches: [ master ]
 
 jobs:
-
   build:
-    name: Build
     runs-on: ubuntu-latest
+
     steps:
+      - uses: actions/checkout@v4
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
-          go-version: ^1.13
-        id: go
+          go-version: '1.21'
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+      - name: Download dependencies
+        run: go mod download
 
-      - name: Get dependencies
-        run: |
-          go get -v -t -d ./...
-          if [ -f Gopkg.toml ]; then
-              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-              dep ensure
-          fi
+      - name: Vet
+        run: go vet ./...
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v4
+        continue-on-error: true
+        with:
+          version: v1.59
+          args: --timeout=5m
 
       - name: Build
-        run: go build -v .
+        run: go build -v ./...
 
       - name: Test
-        run: go test -v ./...
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic $(go list ./... | grep -v examples)
 
-      - name: Generate coverage report
-        run: |
-          go test `go list ./... | grep -v examples` -coverprofile=coverage.txt -covermode=atomic
-
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v1.0.2
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
         with:
-          token: c5f46397-b264-4e3b-9054-17ac9d40662b
-          file: ./coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.txt
           flags: unittests
-          name: codecov-umbrella

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+linters:
+  disable-all: false
+  enable:
+    - govet
+    - ineffassign
+    - errcheck
+    - gosimple
+    - staticcheck


### PR DESCRIPTION
## Summary
- Modernize Go CI to Go 1.21 and current GitHub Actions major versions
- Add dependency download, go vet, golangci-lint, build, race tests, and Codecov v4 upload
- Add a minimal golangci-lint config

## Notes
- The lint step uses `continue-on-error: true` initially so existing legacy lint findings do not block CI while cleanup happens gradually.
- `CODECOV_TOKEN` must be set as a repository secret.
- A parallel security PR handles Codecov token rotation; this workflow update may conflict with that PR on `.github/workflows/go.yml`, which is expected.

## Validation
- `go build ./...`
- `go test ./...`