### PR TITLE
Multi-stage Alpine Dockerfile, modern Go

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+examples
+*.md
+.github
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-FROM golang:1.15
+FROM golang:1.21-alpine AS builder
 
-WORKDIR $GOPATH/src/github.com/arazmj/gerdu
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
 
 COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/gerdu .
 
-RUN go get -d -v ./...
+FROM alpine:3.20
 
-RUN go install -v ./...
-
-EXPOSE 8080
-
-CMD ["gerdu"]
+RUN apk add --no-cache ca-certificates && adduser -D -u 10001 gerdu
+COPY --from=builder /out/gerdu /usr/local/bin/gerdu
+USER gerdu
+EXPOSE 8080 8081 11211 6379 12000
+ENTRYPOINT ["/usr/local/bin/gerdu"]


### PR DESCRIPTION
## Summary
- modernize Dockerfile to Go 1.21 Alpine multi-stage build
- use slim Alpine runtime with non-root user
- document Docker build context exclusions via .dockerignore

## Validation
- go build ./...
- docker build skipped: docker not installed locally