### PR TITLE
feat(lru): account for key bytes in capacity

### DIFF
--- a/httpserver/http_server_test.go
+++ b/httpserver/http_server_test.go
@@ -37,7 +37,7 @@ func TestPutHandlerBadBody(t *testing.T) {
 }
 
 func TestIndexHandler(t *testing.T) {
-	gerdu := lrucache.NewCache(2)
+	gerdu := lrucache.NewCache(4)
 	tests := []struct {
 		name             string
 		r                *http.Request

--- a/lrucache/lru_cache.go
+++ b/lrucache/lru_cache.go
@@ -49,11 +49,15 @@ func expirationFromTTL(ttl time.Duration) time.Time {
 	return time.Now().Add(ttl)
 }
 
+func entrySize(key string, value string) bytesize.ByteSize {
+	return bytesize.ByteSize(len(key) + len(value))
+}
+
 func (c *LRUCache) removeNode(node *dlinklist.Node) {
 	metrics.Deletes.Inc()
 	c.linklist.RemoveNode(node)
 	delete(c.node, node.Key)
-	c.size -= bytesize.ByteSize(len(node.Value))
+	c.size -= entrySize(node.Key, node.Value)
 }
 
 // Get returns the value for the key
@@ -85,27 +89,28 @@ func (c *LRUCache) Put(key string, value string) (created bool) {
 func (c *LRUCache) PutWithTTL(key string, value string, ttl time.Duration) (created bool) {
 	defer c.Unlock()
 	c.Lock()
+
 	expiresAt := expirationFromTTL(ttl)
 	if node, ok := c.node[key]; ok {
-		c.size -= bytesize.ByteSize(len(node.Value))
-		c.size += bytesize.ByteSize(len(value))
+		c.size -= entrySize(node.Key, node.Value)
 		c.linklist.RemoveNode(node)
 		c.linklist.AddNode(node)
 		node.Value = value
 		node.ExpiresAt = expiresAt
+		c.size += entrySize(node.Key, node.Value)
 		created = false
 	} else {
 		node := &dlinklist.Node{Key: key, Value: value, ExpiresAt: expiresAt}
 		c.linklist.AddNode(node)
 		c.node[key] = node
 		metrics.Adds.Inc()
-		c.size += bytesize.ByteSize(len(value))
+		c.size += entrySize(key, value)
 		created = true
 	}
 	for c.size > c.capacity {
 		tail := c.linklist.PopTail()
 		metrics.Deletes.Inc()
-		c.size -= bytesize.ByteSize(len(tail.Value))
+		c.size -= entrySize(tail.Key, tail.Value)
 		delete(c.node, tail.Key)
 	}
 	return created

--- a/lrucache/lru_cache_test.go
+++ b/lrucache/lru_cache_test.go
@@ -10,17 +10,17 @@ import (
 )
 
 func TestLRUCache(t *testing.T) {
-	cache := NewCache(2)
+	cache := NewCache(4)
 	cache.Put("1", "1")
 	cache.Put("2", "2")
 	cache.Put("3", "3")
 	if value, ok := cache.Get("1"); ok {
 		t.Errorf("Expected value 1 to be evicted but got %s %t", value, ok)
 	}
-	if value, ok := cache.Get("2"); value != "2" && !ok {
+	if value, ok := cache.Get("2"); value != "2" || !ok {
 		t.Errorf("Expected value 2 but got %s %t", value, ok)
 	}
-	if value, ok := cache.Get("3"); value != "3" && !ok {
+	if value, ok := cache.Get("3"); value != "3" || !ok {
 		t.Errorf("Expected value 3 but got %s %t", value, ok)
 	}
 }
@@ -70,26 +70,67 @@ func TestLruCache_Delete(t *testing.T) {
 	cache.Delete("1")
 	_, getOk2 := cache.Get("1")
 	if !getOk1 || getOk2 {
-		t.Fatal("Expected the ket to be deleted")
+		t.Fatal("Expected the key to be deleted")
+	}
+}
+
+func TestLRUCacheCapacityIncludesKeyBytes(t *testing.T) {
+	cache := NewCache(5)
+	cache.Put("abc", "de")
+
+	if cache.size != 5 {
+		t.Fatalf("Expected cache size to include key and value bytes, got %d", cache.size)
+	}
+	if _, ok := cache.Get("abc"); !ok {
+		t.Fatal("Expected entry using exactly full key+value capacity to remain cached")
+	}
+}
+
+func TestLRUCacheEvictsWhenKeyValueBytesExceedCapacity(t *testing.T) {
+	cache := NewCache(6)
+	cache.Put("abc", "de")
+	cache.Put("fg", "hi")
+
+	if _, ok := cache.Get("abc"); ok {
+		t.Fatal("Expected oldest entry to be evicted when key+value bytes exceed capacity")
+	}
+	if value, ok := cache.Get("fg"); !ok || value != "hi" {
+		t.Fatalf("Expected newest entry to remain, got value=%q ok=%t", value, ok)
+	}
+	if cache.size != 4 {
+		t.Fatalf("Expected cache size to be decremented by evicted key+value bytes, got %d", cache.size)
+	}
+}
+
+func TestLRUCacheDeleteDecrementsKeyValueBytes(t *testing.T) {
+	cache := NewCache(10)
+	cache.Put("abc", "de")
+	cache.Delete("abc")
+
+	if cache.size != 0 {
+		t.Fatalf("Expected delete to decrement key+value bytes, got %d", cache.size)
 	}
 }
 
 func TestDeleteDecrementsSize(t *testing.T) {
-	cache := NewCache(4)
+	cache := NewCache(18)
+	deletedKey := "deleted"
+	remainingKey := "remainx"
+	newKey := "newkeyx"
 	deletedValue := "aa"
 	remainingValue := "bb"
 	newValue := "cc"
 
-	cache.Put("deleted", deletedValue)
+	cache.Put(deletedKey, deletedValue)
 	sizeAfterFirstPut := cache.size
-	cache.Put("remaining", remainingValue)
+	cache.Put(remainingKey, remainingValue)
 	sizeAfterSecondPut := cache.size
 
-	if !cache.Delete("deleted") {
+	if !cache.Delete(deletedKey) {
 		t.Fatal("expected delete to report success")
 	}
 
-	expectedSize := sizeAfterSecondPut - bytesize.ByteSize(len(deletedValue))
+	expectedSize := sizeAfterSecondPut - entrySize(deletedKey, deletedValue)
 	if cache.size != expectedSize {
 		t.Fatalf("expected size to drop from %s to %s after deleting %q, got %s", sizeAfterSecondPut, expectedSize, deletedValue, cache.size)
 	}
@@ -97,8 +138,8 @@ func TestDeleteDecrementsSize(t *testing.T) {
 		t.Fatalf("expected remaining size %s to match first put size %s", expectedSize, sizeAfterFirstPut)
 	}
 
-	cache.Put("new", newValue)
-	if value, ok := cache.Get("remaining"); !ok || value != remainingValue {
+	cache.Put(newKey, newValue)
+	if value, ok := cache.Get(remainingKey); !ok || value != remainingValue {
 		t.Fatalf("expected remaining entry to survive equivalent-size put, got %q %t", value, ok)
 	}
 }


### PR DESCRIPTION
Tracks len(key)+len(value) toward LRU capacity in Put/Delete/eviction paths. Adds tests.