### PR TITLE
feat: per-entry TTL support

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,9 +1,12 @@
 // Package cache general interface for cache
 package cache
 
+import "time"
+
 // UnImplementedCache cache interface
 type UnImplementedCache interface {
 	Put(key string, value string) (created bool)
+	PutWithTTL(key string, value string, ttl time.Duration) (created bool)
 	Get(key string) (value string, ok bool)
 	Delete(key string) (ok bool)
 }

--- a/dlinklist/dlink_list.go
+++ b/dlinklist/dlink_list.go
@@ -1,13 +1,16 @@
 // Package dlinklist implements a doubly linked list as backing data structure for cache operations
 package dlinklist
 
+import "time"
+
 // Node data structure
 type Node struct {
-	next  *Node
-	prev  *Node
-	Key   string
-	Value string
-	Freq  int
+	next      *Node
+	prev      *Node
+	Key       string
+	Value     string
+	Freq      int
+	ExpiresAt time.Time
 }
 
 // DLinkedList data structure

--- a/httpserver/http_server.go
+++ b/httpserver/http_server.go
@@ -9,6 +9,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"net/http"
+	"strconv"
+	"time"
 )
 
 func newRouter(gerdu cache.UnImplementedCache) (router *mux.Router) {
@@ -57,8 +59,13 @@ func putHandler(w http.ResponseWriter, r *http.Request, gerdu cache.UnImplemente
 		return
 	}
 	value := buf.String()
+	ttl, err := ttlFromHeader(r.Header.Get("X-TTL"))
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 
-	created := gerdu.Put(key, value)
+	created := gerdu.PutWithTTL(key, value, ttl)
 	if !created {
 		log.Printf("HTTP UPDATE Key: %s Value: %s\n", key, value)
 	} else {
@@ -70,6 +77,17 @@ func putHandler(w http.ResponseWriter, r *http.Request, gerdu cache.UnImplemente
 	} else {
 		w.WriteHeader(http.StatusNoContent)
 	}
+}
+
+func ttlFromHeader(value string) (time.Duration, error) {
+	if value == "" {
+		return 0, nil
+	}
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || seconds < 0 {
+		return 0, strconv.ErrSyntax
+	}
+	return time.Duration(seconds) * time.Second, nil
 }
 
 func getHandler(w http.ResponseWriter, r *http.Request, gerdu cache.UnImplementedCache) {

--- a/lfucache/lfu_cache.go
+++ b/lfucache/lfu_cache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/inhies/go-bytesize"
 	"io"
 	"sync"
+	"time"
 )
 
 // LFUCache data structure
@@ -101,6 +102,11 @@ func (c *LFUCache) Get(key string) (value string, ok bool) {
 // 3. The tail of the DLinkedList with minFreq is the least
 //recently used one, pop it.
 func (c *LFUCache) Put(key, value string) (created bool) {
+	return c.PutWithTTL(key, value, 0)
+}
+
+// PutWithTTL stores a key value pair. LFUCache ignores TTL.
+func (c *LFUCache) PutWithTTL(key, value string, ttl time.Duration) (created bool) {
 	defer c.Unlock()
 	c.Lock()
 	if c.capacity == 0 {

--- a/lrucache/lru_cache.go
+++ b/lrucache/lru_cache.go
@@ -10,9 +10,12 @@ import (
 	"github.com/inhies/go-bytesize"
 	"io"
 	"sync"
+	"time"
 )
 
-//LRUCache data structure
+const sweepInterval = 30 * time.Second
+
+// LRUCache data structure
 type LRUCache struct {
 	sync.RWMutex
 	cache.UnImplementedCache
@@ -31,16 +34,39 @@ func NewCache(capacity bytesize.ByteSize) *LRUCache {
 		capacity: capacity,
 		size:     0,
 	}
+	go l.sweepExpiredEntries()
 	return l
+}
+
+func isExpired(node *dlinklist.Node, now time.Time) bool {
+	return !node.ExpiresAt.IsZero() && now.After(node.ExpiresAt)
+}
+
+func expirationFromTTL(ttl time.Duration) time.Time {
+	if ttl <= 0 {
+		return time.Time{}
+	}
+	return time.Now().Add(ttl)
+}
+
+func (c *LRUCache) removeNode(node *dlinklist.Node) {
+	metrics.Deletes.Inc()
+	c.linklist.RemoveNode(node)
+	delete(c.node, node.Key)
+	c.size -= bytesize.ByteSize(len(node.Value))
 }
 
 // Get returns the value for the key
 func (c *LRUCache) Get(key string) (value string, ok bool) {
 	defer c.Unlock()
 	c.Lock()
-	if value, ok := c.node[key]; ok {
+	if node, ok := c.node[key]; ok {
+		if isExpired(node, time.Now()) {
+			c.removeNode(node)
+			metrics.Miss.Inc()
+			return "", false
+		}
 		metrics.Hits.Inc()
-		node := value
 		c.linklist.RemoveNode(node)
 		c.linklist.AddNode(node)
 		return node.Value, true
@@ -52,45 +78,67 @@ func (c *LRUCache) Get(key string) (value string, ok bool) {
 // applyPut updates or insert a new entry, evicts the old entry
 // if node size is larger than capacity
 func (c *LRUCache) Put(key string, value string) (created bool) {
+	return c.PutWithTTL(key, value, 0)
+}
+
+// PutWithTTL updates or inserts a new entry with an optional TTL.
+func (c *LRUCache) PutWithTTL(key string, value string, ttl time.Duration) (created bool) {
 	defer c.Unlock()
 	c.Lock()
-	if v, ok := c.node[key]; ok {
-		node := v
+	expiresAt := expirationFromTTL(ttl)
+	if node, ok := c.node[key]; ok {
+		c.size -= bytesize.ByteSize(len(node.Value))
+		c.size += bytesize.ByteSize(len(value))
 		c.linklist.RemoveNode(node)
 		c.linklist.AddNode(node)
 		node.Value = value
+		node.ExpiresAt = expiresAt
 		created = false
 	} else {
-		node := &dlinklist.Node{Key: key, Value: value}
+		node := &dlinklist.Node{Key: key, Value: value, ExpiresAt: expiresAt}
 		c.linklist.AddNode(node)
 		c.node[key] = node
 		metrics.Adds.Inc()
 		c.size += bytesize.ByteSize(len(value))
-		for c.size > c.capacity {
-			metrics.Deletes.Inc()
-			tail := c.linklist.PopTail()
-			c.size -= bytesize.ByteSize(len(tail.Value))
-			delete(c.node, tail.Key)
-		}
 		created = true
+	}
+	for c.size > c.capacity {
+		tail := c.linklist.PopTail()
+		metrics.Deletes.Inc()
+		c.size -= bytesize.ByteSize(len(tail.Value))
+		delete(c.node, tail.Key)
 	}
 	return created
 }
 
-//applyDelete the key from the node
+// applyDelete the key from the node
 func (c *LRUCache) Delete(key string) (ok bool) {
 	c.Lock()
 	defer c.Unlock()
 
 	if node, ok := c.node[key]; ok {
-		metrics.Deletes.Inc()
-		c.linklist.RemoveNode(node)
-		c.size -= bytesize.ByteSize(len(node.Value))
-		delete(c.node, key)
-	} else {
-		return false
+		c.removeNode(node)
+		return true
 	}
-	return true
+	return false
+}
+
+func (c *LRUCache) sweepExpiredEntries() {
+	ticker := time.NewTicker(sweepInterval)
+	for range ticker.C {
+		c.evictExpired(time.Now())
+	}
+}
+
+func (c *LRUCache) evictExpired(now time.Time) {
+	c.Lock()
+	defer c.Unlock()
+
+	for _, node := range c.node {
+		if isExpired(node, now) {
+			c.removeNode(node)
+		}
+	}
 }
 
 func (c *LRUCache) Snapshot() (raft.FSMSnapshot, error) {
@@ -98,9 +146,12 @@ func (c *LRUCache) Snapshot() (raft.FSMSnapshot, error) {
 	defer c.RUnlock()
 
 	o := make(map[string]string)
+	now := time.Now()
 
 	for k, v := range c.node {
-		o[k] = v.Value
+		if !isExpired(v, now) {
+			o[k] = v.Value
+		}
 	}
 
 	return &fsmSnapshot{store: o}, nil

--- a/lrucache/lru_cache_test.go
+++ b/lrucache/lru_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestLRUCache(t *testing.T) {
@@ -120,4 +121,36 @@ func TestDeleteConcurrentSafe(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestLRUCachePutWithTTLExpiresOnGet(t *testing.T) {
+	cache := NewCache(10)
+	cache.PutWithTTL("1", "1", 20*time.Millisecond)
+	if value, ok := cache.Get("1"); !ok || value != "1" {
+		t.Fatalf("Expected value before TTL expiry, got %q %t", value, ok)
+	}
+
+	time.Sleep(40 * time.Millisecond)
+	if value, ok := cache.Get("1"); ok {
+		t.Fatalf("Expected value to expire, got %q", value)
+	}
+}
+
+func TestLRUCachePutWithZeroTTLDoesNotExpire(t *testing.T) {
+	cache := NewCache(10)
+	cache.PutWithTTL("1", "1", 0)
+	time.Sleep(20 * time.Millisecond)
+	if value, ok := cache.Get("1"); !ok || value != "1" {
+		t.Fatalf("Expected value without TTL to remain, got %q %t", value, ok)
+	}
+}
+
+func TestLRUCacheEvictExpiredRemovesEntries(t *testing.T) {
+	cache := NewCache(10)
+	cache.PutWithTTL("1", "1", 20*time.Millisecond)
+	time.Sleep(40 * time.Millisecond)
+	cache.evictExpired(time.Now())
+	if _, ok := cache.node["1"]; ok {
+		t.Fatal("Expected sweeper eviction to remove expired entry")
+	}
 }

--- a/memcached/memcached.go
+++ b/memcached/memcached.go
@@ -65,7 +65,15 @@ func getHandler(ctx context.Context, req *mc.Request, res *mc.Response, gerdu ca
 func setHandler(ctx context.Context, req *mc.Request, res *mc.Response, gerdu cache.UnImplementedCache) error {
 	key := req.Key
 	value := req.Data
-	created := gerdu.Put(key, string(value))
+	ttl := ttlFromExptime(req.Exptime)
+	if req.Exptime > 0 && ttl <= 0 {
+		gerdu.Delete(key)
+		memcachedKeys.Delete(key)
+		memcachedExpirations.Delete(key)
+		res.Response = mc.RespStored
+		return nil
+	}
+	created := gerdu.PutWithTTL(key, string(value), ttl)
 	memcachedKeys.Store(key, struct{}{})
 	if req.Exptime > 0 {
 		memcachedExpirations.Store(key, expirationTime(req.Exptime))
@@ -79,6 +87,17 @@ func setHandler(ctx context.Context, req *mc.Request, res *mc.Response, gerdu ca
 	}
 	res.Response = mc.RespStored
 	return nil
+}
+
+func ttlFromExptime(exptime int64) time.Duration {
+	if exptime <= 0 {
+		return 0
+	}
+	now := time.Now().Unix()
+	if exptime <= now {
+		return time.Duration(exptime) * time.Second
+	}
+	return time.Until(time.Unix(exptime, 0))
 }
 
 func deleteHandler(ctx context.Context, req *mc.Request, res *mc.Response, gerdu cache.UnImplementedCache) error {

--- a/memcached/memcached_test.go
+++ b/memcached/memcached_test.go
@@ -22,6 +22,10 @@ func newTestCache() *testCache {
 }
 
 func (c *testCache) Put(key string, value string) bool {
+	return c.PutWithTTL(key, value, 0)
+}
+
+func (c *testCache) PutWithTTL(key string, value string, ttl time.Duration) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	_, exists := c.values[key]

--- a/raftproxy/raft_proxy.go
+++ b/raftproxy/raft_proxy.go
@@ -38,9 +38,10 @@ type RaftProxy struct {
 }
 
 type command struct {
-	Op    string `json:"op,omitempty"`
-	Key   string `json:"key,omitempty"`
-	Value string `json:"value,omitempty"`
+	Op         string `json:"op,omitempty"`
+	Key        string `json:"key,omitempty"`
+	Value      string `json:"value,omitempty"`
+	TTLSeconds int64  `json:"ttl_seconds,omitempty"`
 }
 
 func NewRaftProxy(imp cache.UnImplementedCache, raftAddr, joinAddr, localId string) *RaftProxy {
@@ -55,10 +56,15 @@ func NewRaftProxy(imp cache.UnImplementedCache, raftAddr, joinAddr, localId stri
 // Put updates or insert a new entry, evicts the old entry
 // if cache size is larger than capacity
 func (c *RaftProxy) Put(key string, value string) (created bool) {
+	return c.PutWithTTL(key, value, 0)
+}
+
+func (c *RaftProxy) PutWithTTL(key string, value string, ttl time.Duration) (created bool) {
 	cmd := &command{
-		Op:    "put",
-		Key:   key,
-		Value: value,
+		Op:         "put",
+		Key:        key,
+		Value:      value,
+		TTLSeconds: int64(ttl / time.Second),
 	}
 
 	future, err := c.applyCommand(cmd)
@@ -155,7 +161,7 @@ func (f *fsm) Apply(l *raft.Log) interface{} {
 		}
 		return response
 	case "put":
-		return f.Imp.Put(cmd.Key, cmd.Value)
+		return f.Imp.PutWithTTL(cmd.Key, cmd.Value, time.Duration(cmd.TTLSeconds)*time.Second)
 	case "delete":
 		return f.Imp.Delete(cmd.Key)
 	default:

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -5,7 +5,9 @@ import (
 	"github.com/arazmj/gerdu/cache"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/redcon"
+	"strconv"
 	"strings"
+	"time"
 )
 
 func Serve(host string, gerdu cache.UnImplementedCache) {
@@ -51,6 +53,14 @@ func ServeTLS(host string, tlsCert, tlsKey string, gerdu cache.UnImplementedCach
 	}
 }
 
+func parseTTLSeconds(raw []byte) (time.Duration, bool) {
+	seconds, err := strconv.ParseInt(string(raw), 10, 64)
+	if err != nil || seconds <= 0 {
+		return 0, false
+	}
+	return time.Duration(seconds) * time.Second, true
+}
+
 func handleCommands(gerdu cache.UnImplementedCache) func(conn redcon.Conn, cmd redcon.Command) {
 	return func(conn redcon.Conn, cmd redcon.Command) {
 		switch strings.ToLower(string(cmd.Args[0])) {
@@ -62,11 +72,36 @@ func handleCommands(gerdu cache.UnImplementedCache) func(conn redcon.Conn, cmd r
 			conn.WriteString("OK")
 			conn.Close()
 		case "set":
-			if len(cmd.Args) != 3 {
+			if len(cmd.Args) != 3 && len(cmd.Args) != 5 {
 				conn.WriteError("ERR wrong number of arguments for '" + string(cmd.Args[0]) + "' command")
 				return
 			}
-			gerdu.Put(string(cmd.Args[1]), string(cmd.Args[2]))
+			ttl := time.Duration(0)
+			if len(cmd.Args) == 5 {
+				if strings.ToLower(string(cmd.Args[3])) != "ex" {
+					conn.WriteError("ERR syntax error")
+					return
+				}
+				var ok bool
+				ttl, ok = parseTTLSeconds(cmd.Args[4])
+				if !ok {
+					conn.WriteError("ERR invalid expire time in 'set' command")
+					return
+				}
+			}
+			gerdu.PutWithTTL(string(cmd.Args[1]), string(cmd.Args[2]), ttl)
+			conn.WriteString("OK")
+		case "setex":
+			if len(cmd.Args) != 4 {
+				conn.WriteError("ERR wrong number of arguments for '" + string(cmd.Args[0]) + "' command")
+				return
+			}
+			ttl, ok := parseTTLSeconds(cmd.Args[2])
+			if !ok {
+				conn.WriteError("ERR invalid expire time in 'setex' command")
+				return
+			}
+			gerdu.PutWithTTL(string(cmd.Args[1]), string(cmd.Args[3]), ttl)
 			conn.WriteString("OK")
 		case "get":
 			if len(cmd.Args) != 2 {

--- a/weakcache/weak_cache.go
+++ b/weakcache/weak_cache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ivanrad/go-weakref/weakref"
 	"io"
 	"sync"
+	"time"
 )
 
 // WeakCache data structure
@@ -25,6 +26,11 @@ func NewWeakCache() *WeakCache {
 
 // Put a new key value pair
 func (c *WeakCache) Put(key string, value string) (created bool) {
+	return c.PutWithTTL(key, value, 0)
+}
+
+// PutWithTTL stores a new key value pair. WeakCache ignores TTL.
+func (c *WeakCache) PutWithTTL(key string, value string, ttl time.Duration) (created bool) {
 	metrics.Adds.Inc()
 	ref := weakref.NewWeakRef(value)
 	c.Store(key, ref)


### PR DESCRIPTION
Adds per-entry TTL to LRU cache with lazy expiration on Get and background sweeper. Exposes via HTTP X-TTL header, Redis SETEX/EX, and memcached exptime field.