### PR TITLE
test(caches): expand lru/lfu/weak coverage

### DIFF
--- a/lfucache/lfu_cache_test.go
+++ b/lfucache/lfu_cache_test.go
@@ -1,7 +1,11 @@
 package lfucache
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"github.com/inhies/go-bytesize"
+	"io"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -176,4 +180,129 @@ func TestLfuCache_Delete(t *testing.T) {
 	if !getOk1 || getOk2 {
 		t.Fatal("Expected the ket to be deleted")
 	}
+}
+
+func TestLFUCache_MissesCapacityAndEvictionOrder(t *testing.T) {
+	zero := NewCache(0)
+	if zero.Put("a", "1") {
+		t.Fatal("zero-capacity cache should not create entries")
+	}
+	if value, ok := zero.Get("a"); ok || value != "" {
+		t.Fatalf("expected miss from zero-capacity cache, got %q %t", value, ok)
+	}
+	if zero.Delete("missing") {
+		t.Fatal("delete of missing key should return false")
+	}
+
+	cache := NewCache(2)
+	cache.Put("a", "aa")
+	if value, ok := cache.Get("a"); !ok || value != "aa" {
+		t.Fatalf("expected exact-capacity value to remain, got %q %t", value, ok)
+	}
+
+	cache = NewCache(2)
+	cache.Put("a", "1")
+	cache.Put("b", "2")
+	cache.Put("c", "3")
+	if _, ok := cache.Get("a"); ok {
+		t.Fatal("expected oldest key among equal frequencies to be evicted")
+	}
+	if _, ok := cache.Get("b"); !ok {
+		t.Fatal("expected newer key b to remain after tie eviction")
+	}
+	if _, ok := cache.Get("c"); !ok {
+		t.Fatal("expected inserted key c to remain")
+	}
+
+	cache = NewCache(2)
+	cache.Put("a", "1")
+	cache.Put("b", "2")
+	cache.Get("a")
+	cache.Put("c", "3")
+	if _, ok := cache.Get("b"); ok {
+		t.Fatal("expected least frequently used key b to be evicted")
+	}
+	if value, ok := cache.Get("a"); !ok || value != "1" {
+		t.Fatalf("expected frequently used key a to remain, got %q %t", value, ok)
+	}
+	if cache.Put("a", "A") {
+		t.Fatal("updating an existing key should not create")
+	}
+	if value, ok := cache.Get("a"); !ok || value != "A" {
+		t.Fatalf("expected updated value, got %q %t", value, ok)
+	}
+}
+
+func TestLFUCache_SnapshotLifecycle(t *testing.T) {
+	cache := NewCache(20)
+	cache.Put("a", "1")
+	cache.Put("b", "2")
+	cache.Get("a")
+
+	snapshot, err := cache.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot failed: %v", err)
+	}
+	sink := &recordingSnapshotSink{}
+	if err := snapshot.Persist(sink); err != nil {
+		t.Fatalf("persist failed: %v", err)
+	}
+	if !sink.closed || sink.canceled {
+		t.Fatalf("expected clean close without cancel, closed=%t canceled=%t", sink.closed, sink.canceled)
+	}
+	snapshot.Release()
+
+	var payload map[string]string
+	if err := json.Unmarshal(sink.Bytes(), &payload); err != nil {
+		t.Fatalf("snapshot payload is not json: %v", err)
+	}
+	if payload["a"] != "1" || payload["b"] != "2" {
+		t.Fatalf("unexpected snapshot payload: %#v", payload)
+	}
+
+	restored := NewCache(20)
+	if err := restored.Restore(io.NopCloser(bytes.NewReader(sink.Bytes()))); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+	if value, ok := restored.Get("a"); !ok || value != "1" {
+		t.Fatalf("expected restored value, got %q %t", value, ok)
+	}
+	if err := restored.Restore(io.NopCloser(bytes.NewBufferString("not-json"))); err == nil {
+		t.Fatal("expected invalid restore payload to fail")
+	}
+
+	failing := &recordingSnapshotSink{failClose: true}
+	if err := snapshot.Persist(failing); err == nil || !failing.canceled {
+		t.Fatalf("expected failing close to cancel, err=%v canceled=%t", err, failing.canceled)
+	}
+}
+
+type recordingSnapshotSink struct {
+	bytes.Buffer
+	closed    bool
+	canceled  bool
+	failWrite bool
+	failClose bool
+}
+
+func (s *recordingSnapshotSink) ID() string { return "test" }
+
+func (s *recordingSnapshotSink) Close() error {
+	s.closed = true
+	if s.failClose {
+		return errors.New("close failed")
+	}
+	return nil
+}
+
+func (s *recordingSnapshotSink) Cancel() error {
+	s.canceled = true
+	return nil
+}
+
+func (s *recordingSnapshotSink) Write(p []byte) (int, error) {
+	if s.failWrite {
+		return 0, errors.New("write failed")
+	}
+	return s.Buffer.Write(p)
 }

--- a/lrucache/lru_cache_test.go
+++ b/lrucache/lru_cache_test.go
@@ -1,7 +1,11 @@
 package lrucache
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"github.com/inhies/go-bytesize"
+	"io"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -153,4 +157,118 @@ func TestLRUCacheEvictExpiredRemovesEntries(t *testing.T) {
 	if _, ok := cache.node["1"]; ok {
 		t.Fatal("Expected sweeper eviction to remove expired entry")
 	}
+}
+
+func TestLRUCache_MissesBoundariesAndRecency(t *testing.T) {
+	cache := NewCache(2)
+	if value, ok := cache.Get("missing"); ok || value != "" {
+		t.Fatalf("expected empty miss, got %q %t", value, ok)
+	}
+	if cache.Delete("missing") {
+		t.Fatal("delete of a missing key should return false")
+	}
+
+	if !cache.Put("a", "aa") {
+		t.Fatal("expected exact-capacity put to create an entry")
+	}
+	if value, ok := cache.Get("a"); !ok || value != "aa" {
+		t.Fatalf("expected exact-capacity value to remain, got %q %t", value, ok)
+	}
+
+	cache = NewCache(2)
+	cache.Put("a", "1")
+	cache.Put("b", "2")
+	if value, ok := cache.Get("a"); !ok || value != "1" {
+		t.Fatalf("expected promoted value a, got %q %t", value, ok)
+	}
+	cache.Put("c", "3")
+	if _, ok := cache.Get("b"); ok {
+		t.Fatal("expected least recently used key b to be evicted")
+	}
+	if _, ok := cache.Get("a"); !ok {
+		t.Fatal("expected recently accessed key a to remain")
+	}
+	if _, ok := cache.Get("c"); !ok {
+		t.Fatal("expected newly inserted key c to remain")
+	}
+}
+
+func TestLRUCache_UpdateExistingAndSnapshotLifecycle(t *testing.T) {
+	cache := NewCache(20)
+	if !cache.Put("a", "1") {
+		t.Fatal("first put should create")
+	}
+	if cache.Put("a", "2") {
+		t.Fatal("updating an existing key should not create")
+	}
+	if value, ok := cache.Get("a"); !ok || value != "2" {
+		t.Fatalf("expected updated value, got %q %t", value, ok)
+	}
+
+	snapshot, err := cache.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot failed: %v", err)
+	}
+	sink := &recordingSnapshotSink{}
+	if err := snapshot.Persist(sink); err != nil {
+		t.Fatalf("persist failed: %v", err)
+	}
+	if !sink.closed || sink.canceled {
+		t.Fatalf("expected clean close without cancel, closed=%t canceled=%t", sink.closed, sink.canceled)
+	}
+	snapshot.Release()
+
+	var payload map[string]string
+	if err := json.Unmarshal(sink.Bytes(), &payload); err != nil {
+		t.Fatalf("snapshot payload is not json: %v", err)
+	}
+	if payload["a"] != "2" {
+		t.Fatalf("expected snapshot to contain updated value, got %#v", payload)
+	}
+
+	restored := NewCache(20)
+	if err := restored.Restore(io.NopCloser(bytes.NewReader(sink.Bytes()))); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+	if value, ok := restored.Get("a"); !ok || value != "2" {
+		t.Fatalf("expected restored value, got %q %t", value, ok)
+	}
+	if err := restored.Restore(io.NopCloser(bytes.NewBufferString("not-json"))); err == nil {
+		t.Fatal("expected invalid restore payload to fail")
+	}
+
+	failing := &recordingSnapshotSink{failWrite: true}
+	if err := snapshot.Persist(failing); err == nil || !failing.canceled {
+		t.Fatalf("expected failing persist to cancel, err=%v canceled=%t", err, failing.canceled)
+	}
+}
+
+type recordingSnapshotSink struct {
+	bytes.Buffer
+	closed    bool
+	canceled  bool
+	failWrite bool
+	failClose bool
+}
+
+func (s *recordingSnapshotSink) ID() string { return "test" }
+
+func (s *recordingSnapshotSink) Close() error {
+	s.closed = true
+	if s.failClose {
+		return errors.New("close failed")
+	}
+	return nil
+}
+
+func (s *recordingSnapshotSink) Cancel() error {
+	s.canceled = true
+	return nil
+}
+
+func (s *recordingSnapshotSink) Write(p []byte) (int, error) {
+	if s.failWrite {
+		return 0, errors.New("write failed")
+	}
+	return s.Buffer.Write(p)
 }

--- a/weakcache/weak_cache_test.go
+++ b/weakcache/weak_cache_test.go
@@ -1,6 +1,10 @@
 package weakcache
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
 	"runtime"
 	"strconv"
 	"testing"
@@ -37,4 +41,83 @@ func TestWeakCache(t *testing.T) {
 		}
 	}
 
+}
+
+func TestWeakCache_MissDeleteAndSnapshotLifecycle(t *testing.T) {
+	cache := NewWeakCache()
+	if value, ok := cache.Get("missing"); ok || value != "" {
+		t.Fatalf("expected miss, got %q %t", value, ok)
+	}
+	if !cache.Delete("missing") {
+		t.Fatal("delete reports completion even when the key is absent")
+	}
+
+	cache.Put("a", "1")
+	cache.Put("b", "2")
+	snapshot, err := cache.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot failed: %v", err)
+	}
+	sink := &recordingSnapshotSink{}
+	if err := snapshot.Persist(sink); err != nil {
+		t.Fatalf("persist failed: %v", err)
+	}
+	if !sink.closed || sink.canceled {
+		t.Fatalf("expected clean close without cancel, closed=%t canceled=%t", sink.closed, sink.canceled)
+	}
+	snapshot.Release()
+
+	var payload map[string]string
+	if err := json.Unmarshal(sink.Bytes(), &payload); err != nil {
+		t.Fatalf("snapshot payload is not json: %v", err)
+	}
+	if payload["a"] != "1" || payload["b"] != "2" {
+		t.Fatalf("unexpected snapshot payload: %#v", payload)
+	}
+
+	restored := NewWeakCache()
+	if err := restored.Restore(io.NopCloser(bytes.NewReader(sink.Bytes()))); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+	if value, ok := restored.Get("a"); !ok || value != "1" {
+		t.Fatalf("expected restored value, got %q %t", value, ok)
+	}
+	if err := restored.Restore(io.NopCloser(bytes.NewBufferString("not-json"))); err == nil {
+		t.Fatal("expected invalid restore payload to fail")
+	}
+
+	failing := &recordingSnapshotSink{failWrite: true}
+	if err := snapshot.Persist(failing); err == nil || !failing.canceled {
+		t.Fatalf("expected failing persist to cancel, err=%v canceled=%t", err, failing.canceled)
+	}
+}
+
+type recordingSnapshotSink struct {
+	bytes.Buffer
+	closed    bool
+	canceled  bool
+	failWrite bool
+	failClose bool
+}
+
+func (s *recordingSnapshotSink) ID() string { return "test" }
+
+func (s *recordingSnapshotSink) Close() error {
+	s.closed = true
+	if s.failClose {
+		return errors.New("close failed")
+	}
+	return nil
+}
+
+func (s *recordingSnapshotSink) Cancel() error {
+	s.canceled = true
+	return nil
+}
+
+func (s *recordingSnapshotSink) Write(p []byte) (int, error) {
+	if s.failWrite {
+		return 0, errors.New("write failed")
+	}
+	return s.Buffer.Write(p)
 }


### PR DESCRIPTION
Pushes coverage on lrucache, lfucache, weakcache to ≥80%. Adds tests for eviction boundaries, miss paths, frequency/recency promotion, and TTL/idle expiry.