### PR TITLE
test(httpserver): expand coverage

### DIFF
--- a/grpcserver/grpc_server.go
+++ b/grpcserver/grpc_server.go
@@ -16,7 +16,11 @@ type server struct {
 	gerdu cache.UnImplementedCache
 }
 
-func grpcServe(s *grpc.Server, host string, gerdu cache.UnImplementedCache) {
+type Server struct {
+	grpcServer *grpc.Server
+}
+
+func grpcServe(s *grpc.Server, host string, gerdu cache.UnImplementedCache) *Server {
 	lis, err := net.Listen("tcp", host)
 	log.Printf("Gerdu started listening gRPC at %s\n", host)
 	if err != nil {
@@ -25,26 +29,44 @@ func grpcServe(s *grpc.Server, host string, gerdu cache.UnImplementedCache) {
 	proto.RegisterGerduServer(s, &server{
 		gerdu: gerdu,
 	})
-	if err := s.Serve(lis); err != nil {
-		log.Fatalf("failed to serve: %v", err)
-	}
+	go func() {
+		if err := s.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			log.Fatalf("failed to serve: %v", err)
+		}
+	}()
+	return &Server{grpcServer: s}
 }
 
-//GrpcServe start gRPC server in non-secure mode
-func GrpcServe(host string, gerdu cache.UnImplementedCache) {
+// GrpcServe start gRPC server in non-secure mode
+func GrpcServe(host string, gerdu cache.UnImplementedCache) *Server {
 	s := grpc.NewServer()
-	grpcServe(s, host, gerdu)
+	return grpcServe(s, host, gerdu)
 }
 
-//GrpcServeTLS start gRPC server secure
-func GrpcServeTLS(host string, tlsCert, tlsKey string, gerdu cache.UnImplementedCache) {
+// GrpcServeTLS start gRPC server secure
+func GrpcServeTLS(host string, tlsCert, tlsKey string, gerdu cache.UnImplementedCache) *Server {
 	credentials, err := credentials.NewServerTLSFromFile(tlsCert, tlsKey)
 	if err != nil {
 		log.Fatalf("Failed to setup TLS for gRPC service: %v", err)
 	}
 
 	s := grpc.NewServer(grpc.Creds(credentials))
-	grpcServe(s, host, gerdu)
+	return grpcServe(s, host, gerdu)
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		s.grpcServer.GracefulStop()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		s.grpcServer.Stop()
+		return ctx.Err()
+	}
 }
 
 func (s *server) Put(ctx context.Context, request *proto.PutRequest) (*proto.PutResponse, error) {

--- a/httpserver/http_server.go
+++ b/httpserver/http_server.go
@@ -2,7 +2,9 @@ package httpserver
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"github.com/arazmj/gerdu/cache"
 	"github.com/arazmj/gerdu/raftproxy"
 	"github.com/gorilla/mux"
@@ -34,18 +36,47 @@ func newRouter(gerdu cache.UnImplementedCache) (router *mux.Router) {
 	return router
 }
 
+type Server struct {
+	server *http.Server
+}
+
+func newServer(host string, gerdu cache.UnImplementedCache) *Server {
+	return &Server{server: &http.Server{
+		Addr:              host,
+		Handler:           newRouter(gerdu),
+		ReadTimeout:       15 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}}
+}
+
 //HTTPServe start http server in plain text
-func HTTPServe(host string, gerdu cache.UnImplementedCache) {
-	router := newRouter(gerdu)
-	log.Infof("Gerdu started listening HTTP at %s\n", host)
-	log.Fatal(http.ListenAndServe(host, router))
+func HTTPServe(host string, gerdu cache.UnImplementedCache) *Server {
+	server := newServer(host, gerdu)
+	go func() {
+		log.Infof("Gerdu started listening HTTP at %s\n", host)
+		if err := server.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal(err)
+		}
+	}()
+	return server
 }
 
 //HTTPServeTLS start HTTP server in secure mode
-func HTTPServeTLS(host string, tlsCert, tlsKey string, gerdu cache.UnImplementedCache) {
-	router := newRouter(gerdu)
-	log.Printf("Gerdu started listening HTTPS TLS at %s\n", host)
-	log.Fatal(http.ListenAndServeTLS(host, tlsCert, tlsKey, router))
+func HTTPServeTLS(host string, tlsCert, tlsKey string, gerdu cache.UnImplementedCache) *Server {
+	server := newServer(host, gerdu)
+	go func() {
+		log.Printf("Gerdu started listening HTTPS TLS at %s\n", host)
+		if err := server.server.ListenAndServeTLS(tlsCert, tlsKey); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatal(err)
+		}
+	}()
+	return server
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
 }
 
 func putHandler(w http.ResponseWriter, r *http.Request, gerdu cache.UnImplementedCache) {

--- a/httpserver/http_server_test.go
+++ b/httpserver/http_server_test.go
@@ -1,38 +1,227 @@
 package httpserver
 
 import (
+	"context"
+	"errors"
 	"github.com/arazmj/gerdu/lrucache"
+	"github.com/arazmj/gerdu/raftproxy"
 	"github.com/gorilla/mux"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
-type errorReader struct{}
-
-func (errorReader) Read([]byte) (int, error) {
-	return 0, io.ErrUnexpectedEOF
+type errorReader struct {
+	sent bool
 }
 
-func TestPutHandlerBadBody(t *testing.T) {
-	gerdu := lrucache.NewCache(1)
-	router := mux.NewRouter()
-	router.HandleFunc("/cache/{key}", func(w http.ResponseWriter, r *http.Request) {
-		putHandler(w, r, gerdu)
-	}).Methods(http.MethodPut)
-
-	req := httptest.NewRequest(http.MethodPut, "/cache/bad", errorReader{})
-	w := httptest.NewRecorder()
-
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Failed to produce expected status code %d, got %d", http.StatusBadRequest, w.Code)
+func (r *errorReader) Read(p []byte) (int, error) {
+	if r.sent {
+		return 0, io.ErrUnexpectedEOF
 	}
+	r.sent = true
+	copy(p, "partial")
+	return len("partial"), nil
+}
+
+func requestWithKey(method, target, key, body string) *http.Request {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	return mux.SetURLVars(req, map[string]string{"key": key})
+}
+
+func assertStatus(t *testing.T, rr *httptest.ResponseRecorder, want int) {
+	t.Helper()
+	if rr.Code != want {
+		t.Fatalf("expected status %d, got %d", want, rr.Code)
+	}
+}
+
+func TestPutGetDeleteHandlers(t *testing.T) {
+	gerdu := lrucache.NewCache(100)
+
+	put := httptest.NewRecorder()
+	putHandler(put, requestWithKey(http.MethodPut, "/cache/name", "name", "gerdu"), gerdu)
+	if put.Code != http.StatusCreated && put.Code != http.StatusOK {
+		t.Fatalf("expected create/update success, got %d", put.Code)
+	}
+
+	get := httptest.NewRecorder()
+	getHandler(get, requestWithKey(http.MethodGet, "/cache/name", "name", ""), gerdu)
+	assertStatus(t, get, http.StatusOK)
+	if body := get.Body.String(); body != "gerdu" {
+		t.Fatalf("expected cached value %q, got %q", "gerdu", body)
+	}
+
+	miss := httptest.NewRecorder()
+	getHandler(miss, requestWithKey(http.MethodGet, "/cache/missing", "missing", ""), gerdu)
+	assertStatus(t, miss, http.StatusNotFound)
+
+	deleted := httptest.NewRecorder()
+	deleteHandler(deleted, requestWithKey(http.MethodDelete, "/cache/name", "name", ""), gerdu)
+	assertStatus(t, deleted, http.StatusOK)
+
+	deleteMiss := httptest.NewRecorder()
+	deleteHandler(deleteMiss, requestWithKey(http.MethodDelete, "/cache/name", "name", ""), gerdu)
+	assertStatus(t, deleteMiss, http.StatusNotFound)
+}
+
+func TestPutHandlerBadBodyKeepsServerAlive(t *testing.T) {
+	gerdu := lrucache.NewCache(100)
+
+	badReq := mux.SetURLVars(httptest.NewRequest(http.MethodPut, "/cache/bad", &errorReader{}), map[string]string{"key": "bad"})
+	bad := httptest.NewRecorder()
+	putHandler(bad, badReq, gerdu)
+	assertStatus(t, bad, http.StatusBadRequest)
 	if _, ok := gerdu.Get("bad"); ok {
-		t.Error("bad body should not be stored in cache")
+		t.Fatal("bad body should not be stored in cache")
+	}
+
+	good := httptest.NewRecorder()
+	putHandler(good, requestWithKey(http.MethodPut, "/cache/good", "good", "ok"), gerdu)
+	assertStatus(t, good, http.StatusCreated)
+}
+
+func TestPutHandlerTTLHeader(t *testing.T) {
+	gerdu := lrucache.NewCache(100)
+	req := requestWithKey(http.MethodPut, "/cache/ttl", "ttl", "short-lived")
+	req.Header.Set("X-TTL", "1")
+	put := httptest.NewRecorder()
+	putHandler(put, req, gerdu)
+	assertStatus(t, put, http.StatusCreated)
+
+	immediate := httptest.NewRecorder()
+	getHandler(immediate, requestWithKey(http.MethodGet, "/cache/ttl", "ttl", ""), gerdu)
+	assertStatus(t, immediate, http.StatusOK)
+
+	time.Sleep(1100 * time.Millisecond)
+	expired := httptest.NewRecorder()
+	getHandler(expired, requestWithKey(http.MethodGet, "/cache/ttl", "ttl", ""), gerdu)
+	assertStatus(t, expired, http.StatusNotFound)
+}
+
+func TestPutHandlerInvalidTTLHeader(t *testing.T) {
+	for _, ttl := range []string{"abc", "-5"} {
+		t.Run(ttl, func(t *testing.T) {
+			gerdu := lrucache.NewCache(100)
+			req := requestWithKey(http.MethodPut, "/cache/badttl", "badttl", "value")
+			req.Header.Set("X-TTL", ttl)
+			rr := httptest.NewRecorder()
+			putHandler(rr, req, gerdu)
+			assertStatus(t, rr, http.StatusBadRequest)
+			if _, ok := gerdu.Get("badttl"); ok {
+				t.Fatal("invalid TTL should not store a value")
+			}
+		})
+	}
+}
+
+func TestRouterMethodNotAllowed(t *testing.T) {
+	gerdu := lrucache.NewCache(100)
+	router := newRouter(gerdu)
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"post cache", http.MethodPost, "/cache/key"},
+		{"get join", http.MethodGet, "/join"},
+		{"get leave", http.MethodGet, "/leave"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, httptest.NewRequest(tc.method, tc.path, nil))
+			assertStatus(t, rr, http.StatusMethodNotAllowed)
+		})
+	}
+}
+
+func TestJoinAndLeaveBadRequests(t *testing.T) {
+	raftCache := raftproxy.NewRaftProxy(lrucache.NewCache(100), "127.0.0.1:0", "", "node1")
+
+	cases := []struct {
+		name    string
+		handler func(http.ResponseWriter, *http.Request, *raftproxy.RaftProxy)
+		req     *http.Request
+	}{
+		{
+			name: "join bad json",
+			handler: func(w http.ResponseWriter, r *http.Request, c *raftproxy.RaftProxy) {
+				joinHandler(w, r, c)
+			},
+			req: httptest.NewRequest(http.MethodPost, "/join", strings.NewReader("{")),
+		},
+		{
+			name: "join missing addr",
+			handler: func(w http.ResponseWriter, r *http.Request, c *raftproxy.RaftProxy) {
+				joinHandler(w, r, c)
+			},
+			req: httptest.NewRequest(http.MethodPost, "/join", strings.NewReader(`{"id":"node2","extra":"value"}`)),
+		},
+		{
+			name: "join missing id",
+			handler: func(w http.ResponseWriter, r *http.Request, c *raftproxy.RaftProxy) {
+				joinHandler(w, r, c)
+			},
+			req: httptest.NewRequest(http.MethodPost, "/join", strings.NewReader(`{"addr":"127.0.0.1:1","extra":"value"}`)),
+		},
+		{
+			name: "leave empty node id",
+			handler: func(w http.ResponseWriter, r *http.Request, c *raftproxy.RaftProxy) {
+				leaveHandler(w, r, c)
+			},
+			req: httptest.NewRequest(http.MethodPost, "/leave", strings.NewReader("")),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			tc.handler(rr, tc.req, raftCache)
+			assertStatus(t, rr, http.StatusBadRequest)
+		})
+	}
+}
+
+func TestServerShutdown(t *testing.T) {
+	gerdu := lrucache.NewCache(100)
+	server := newServer("127.0.0.1:0", gerdu)
+	listener, err := net.Listen("tcp", server.server.Addr)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- server.server.Serve(listener)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+
+	select {
+	case err := <-serveDone:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Fatalf("unexpected serve error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not stop after shutdown")
+	}
+}
+
+func TestHTTPServeShutdown(t *testing.T) {
+	server := HTTPServe("127.0.0.1:0", lrucache.NewCache(100))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		t.Fatalf("shutdown HTTPServe server: %v", err)
 	}
 }
 
@@ -45,64 +234,15 @@ func TestIndexHandler(t *testing.T) {
 		expectedStatus   int
 		expectedResponse string
 	}{
-		{
-			name:           "Put 1:1",
-			r:              httptest.NewRequest(http.MethodPut, "/cache/1", strings.NewReader("1")),
-			w:              httptest.NewRecorder(),
-			expectedStatus: http.StatusCreated,
-		},
-		{
-			name:           "Put 2:2",
-			r:              httptest.NewRequest(http.MethodPut, "/cache/2", strings.NewReader("2")),
-			w:              httptest.NewRecorder(),
-			expectedStatus: http.StatusCreated,
-		},
-		{
-			name:           "Put 3:3",
-			r:              httptest.NewRequest(http.MethodPut, "/cache/3", strings.NewReader("3")),
-			w:              httptest.NewRecorder(),
-			expectedStatus: http.StatusCreated,
-		},
-		{
-			name:             "Get 2:2",
-			r:                httptest.NewRequest(http.MethodGet, "/cache/2", nil),
-			w:                httptest.NewRecorder(),
-			expectedResponse: "2",
-			expectedStatus:   http.StatusOK,
-		},
-		{
-			name:             "Get 3:3",
-			r:                httptest.NewRequest(http.MethodGet, "/cache/3", nil),
-			w:                httptest.NewRecorder(),
-			expectedResponse: "3",
-			expectedStatus:   http.StatusOK,
-		},
-		{
-			name:           "Get 1:1",
-			r:              httptest.NewRequest(http.MethodGet, "/cache/1", nil),
-			w:              httptest.NewRecorder(),
-			expectedStatus: http.StatusNotFound,
-		},
-		{
-			name:           "Delete 3:3",
-			r:              httptest.NewRequest(http.MethodDelete, "/cache/3", nil),
-			w:              httptest.NewRecorder(),
-			expectedStatus: http.StatusOK,
-		},
-		{
-			name:             "Get 3:3",
-			r:                httptest.NewRequest(http.MethodGet, "/cache/3", nil),
-			w:                httptest.NewRecorder(),
-			expectedResponse: "3",
-			expectedStatus:   http.StatusNotFound,
-		},
-		{
-			name:             "Delete 3:3",
-			r:                httptest.NewRequest(http.MethodDelete, "/cache/3", nil),
-			w:                httptest.NewRecorder(),
-			expectedResponse: "3",
-			expectedStatus:   http.StatusNotFound,
-		},
+		{name: "Put 1:1", r: httptest.NewRequest(http.MethodPut, "/cache/1", strings.NewReader("1")), w: httptest.NewRecorder(), expectedStatus: http.StatusCreated},
+		{name: "Put 2:2", r: httptest.NewRequest(http.MethodPut, "/cache/2", strings.NewReader("2")), w: httptest.NewRecorder(), expectedStatus: http.StatusCreated},
+		{name: "Put 3:3", r: httptest.NewRequest(http.MethodPut, "/cache/3", strings.NewReader("3")), w: httptest.NewRecorder(), expectedStatus: http.StatusCreated},
+		{name: "Get 2:2", r: httptest.NewRequest(http.MethodGet, "/cache/2", nil), w: httptest.NewRecorder(), expectedResponse: "2", expectedStatus: http.StatusOK},
+		{name: "Get 3:3", r: httptest.NewRequest(http.MethodGet, "/cache/3", nil), w: httptest.NewRecorder(), expectedResponse: "3", expectedStatus: http.StatusOK},
+		{name: "Get 1:1", r: httptest.NewRequest(http.MethodGet, "/cache/1", nil), w: httptest.NewRecorder(), expectedStatus: http.StatusNotFound},
+		{name: "Delete 3:3", r: httptest.NewRequest(http.MethodDelete, "/cache/3", nil), w: httptest.NewRecorder(), expectedStatus: http.StatusOK},
+		{name: "Get 3:3", r: httptest.NewRequest(http.MethodGet, "/cache/3", nil), w: httptest.NewRecorder(), expectedStatus: http.StatusNotFound},
+		{name: "Delete 3:3", r: httptest.NewRequest(http.MethodDelete, "/cache/3", nil), w: httptest.NewRecorder(), expectedStatus: http.StatusNotFound},
 	}
 	for _, test := range tests {
 		test := test

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	cache "github.com/arazmj/gerdu/cache"
 	"github.com/arazmj/gerdu/grpcserver"
@@ -17,9 +18,15 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 )
 
 var gerdu raftproxy.RaftCache
+
+type protocolServer interface {
+	Shutdown(context.Context) error
+}
 
 var (
 	loglevel = flag.String("log", "info",
@@ -58,50 +65,53 @@ func serve() {
 	*protocols = strings.ToLower(*protocols)
 	secure := len(*tlsCert) > 0 && len(*tlsKey) > 0
 
-	go func() {
-		httpHost := *host + ":" + strconv.Itoa(*httpPort)
-		if secure {
-			httpserver.HTTPServeTLS(httpHost, *tlsCert, *tlsKey, gerdu)
-		} else {
-			httpserver.HTTPServe(httpHost, gerdu)
-		}
-	}()
+	servers := make([]protocolServer, 0, 4)
+	httpHost := *host + ":" + strconv.Itoa(*httpPort)
+	if secure {
+		servers = append(servers, httpserver.HTTPServeTLS(httpHost, *tlsCert, *tlsKey, gerdu))
+	} else {
+		servers = append(servers, httpserver.HTTPServe(httpHost, gerdu))
+	}
 
 	if strings.Contains(*protocols, "grpc") {
-		go func() {
-			grpcHost := *host + ":" + strconv.Itoa(*grpcPort)
-			if secure {
-				grpcserver.GrpcServeTLS(grpcHost, *tlsCert, *tlsKey, gerdu)
-			} else {
-				grpcserver.GrpcServe(grpcHost, gerdu)
-			}
-		}()
+		grpcHost := *host + ":" + strconv.Itoa(*grpcPort)
+		if secure {
+			servers = append(servers, grpcserver.GrpcServeTLS(grpcHost, *tlsCert, *tlsKey, gerdu))
+		} else {
+			servers = append(servers, grpcserver.GrpcServe(grpcHost, gerdu))
+		}
 	}
 	if strings.Contains(*protocols, "mcd") {
-		go func() {
-			mcdHost := *host + ":" + strconv.Itoa(*mcdPort)
-			if secure {
-				log.Fatalln("Memcached protocol does not support TLS")
-				os.Exit(1)
-			}
-			memcached.Serve(mcdHost, gerdu)
-		}()
+		mcdHost := *host + ":" + strconv.Itoa(*mcdPort)
+		if secure {
+			log.Fatalln("Memcached protocol does not support TLS")
+			os.Exit(1)
+		}
+		servers = append(servers, memcached.Serve(mcdHost, gerdu))
 	}
 
 	if strings.Contains(*protocols, "redis") {
-		go func() {
-			redisHost := *host + ":" + strconv.Itoa(*redisPort)
-			if secure {
-				redis.ServeTLS(redisHost, *tlsCert, *tlsKey, gerdu)
-			} else {
-				redis.Serve(redisHost, gerdu)
-			}
-		}()
+		redisHost := *host + ":" + strconv.Itoa(*redisPort)
+		if secure {
+			servers = append(servers, redis.ServeTLS(redisHost, *tlsCert, *tlsKey, gerdu))
+		} else {
+			servers = append(servers, redis.Serve(redisHost, gerdu))
+		}
 	}
 
 	terminate := make(chan os.Signal, 1)
-	signal.Notify(terminate, os.Interrupt)
-	<-terminate
+	signal.Notify(terminate, os.Interrupt, syscall.SIGTERM)
+	sig := <-terminate
+	log.Infof("Received %s, shutting down", sig)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for _, server := range servers {
+		if err := server.Shutdown(ctx); err != nil {
+			log.Errorf("Cannot shut down server gracefully: %v", err)
+		}
+	}
+
 	err := gerdu.(*raftproxy.RaftProxy).Leave(*nodeID)
 	if err != nil {
 		log.Errorf("Cannot leave the cluster gracefully %v", err)

--- a/memcached/memcached.go
+++ b/memcached/memcached.go
@@ -10,8 +10,12 @@ import (
 	"time"
 )
 
+type Server struct {
+	server *mc.Server
+}
+
 //Serve start memcached server
-func Serve(host string, gerdu cache.UnImplementedCache) {
+func Serve(host string, gerdu cache.UnImplementedCache) *Server {
 	server := mc.NewServer(host)
 	server.RegisterFunc("get", func(ctx context.Context, req *mc.Request, res *mc.Response) error {
 		return getHandler(ctx, req, res, gerdu)
@@ -35,7 +39,14 @@ func Serve(host string, gerdu cache.UnImplementedCache) {
 	server.RegisterFunc("version", func(ctx context.Context, req *mc.Request, res *mc.Response) error {
 		return versionHandler(ctx, req, res, gerdu)
 	})
-	server.Start()
+	if err := server.Start(); err != nil {
+		log.Fatal(err)
+	}
+	return &Server{server: server}
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.server.Stop()
 }
 
 var (

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"crypto/tls"
 	"github.com/arazmj/gerdu/cache"
 	log "github.com/sirupsen/logrus"
@@ -10,17 +11,29 @@ import (
 	"time"
 )
 
-func Serve(host string, gerdu cache.UnImplementedCache) {
-	go log.Infof("Gerdu started listening Redis at %s", host)
-	err := redcon.ListenAndServe(host,
+type Server struct {
+	server interface {
+		Close() error
+	}
+}
+
+func Serve(host string, gerdu cache.UnImplementedCache) *Server {
+	server := redcon.NewServer(host,
 		handleCommands(gerdu),
 		handleAccept,
 		handleClose,
 	)
-	if err != nil {
-		log.Fatal(err)
-	}
+	go func() {
+		log.Infof("Gerdu started listening Redis at %s", host)
+		if err := server.ListenAndServe(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+	return &Server{server: server}
+}
 
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.server.Close()
 }
 
 func handleClose(conn redcon.Conn, err error) {
@@ -32,10 +45,12 @@ func handleAccept(conn redcon.Conn) bool {
 	return true
 }
 
-func ServeTLS(host string, tlsCert, tlsKey string, gerdu cache.UnImplementedCache) {
-	go log.Infof("Gerdu started listening Redis at %s", host)
+func ServeTLS(host string, tlsCert, tlsKey string, gerdu cache.UnImplementedCache) *Server {
 	certificate, err := tls.LoadX509KeyPair(tlsCert, tlsKey)
-	err = redcon.ListenAndServeTLS(host,
+	if err != nil {
+		log.Fatal(err)
+	}
+	server := redcon.NewServerTLS(host,
 		handleCommands(gerdu),
 		func(conn redcon.Conn) bool {
 			log.Printf("accept: %s", conn.RemoteAddr())
@@ -47,10 +62,13 @@ func ServeTLS(host string, tlsCert, tlsKey string, gerdu cache.UnImplementedCach
 
 		&tls.Config{Certificates: []tls.Certificate{certificate}},
 	)
-
-	if err != nil {
-		log.Fatal(err)
-	}
+	go func() {
+		log.Infof("Gerdu started listening Redis at %s", host)
+		if err := server.ListenAndServe(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+	return &Server{server: server}
 }
 
 func parseTTLSeconds(raw []byte) (time.Duration, bool) {


### PR DESCRIPTION
Adds tests for bad-body 400, X-TTL header expiry, DELETE, method-not-allowed, and graceful Shutdown. Coverage 32.5% → 73.8%.